### PR TITLE
allow copy of a Timeout object

### DIFF
--- a/src/Timeout.hpp
+++ b/src/Timeout.hpp
@@ -9,7 +9,7 @@ namespace iodrivers_base {
  */
 class Timeout {
 private:
-    unsigned int const timeout;
+    unsigned int timeout;
     timeval start_time;
 
 public:


### PR DESCRIPTION
There's really nothing against it, and it allows the easy
reinitialization of a Timeout attribute in a class with e.g.

  mTimeout = Timeout(100);
