### PR TITLE
fix -Wtautological-compare

### DIFF
--- a/src/IOStream.cpp
+++ b/src/IOStream.cpp
@@ -103,7 +103,7 @@ UDPServerStream::UDPServerStream(int fd, bool auto_close)
  
 size_t UDPServerStream::read(uint8_t* buffer, size_t buffer_size)
 {
-  size_t ret = recvfrom(m_fd, buffer, buffer_size, 0, &m_si_other, &m_s_len);
+  ssize_t ret = recvfrom(m_fd, buffer, buffer_size, 0, &m_si_other, &m_s_len);
   if (ret >= 0){
      return ret;
   }


### PR DESCRIPTION
this is not well: casting a signed value to unsigned and then checking for greater than zero

```
.../drivers/iodrivers_base/src/IOStream.cpp:107:11: warning: comparison of unsigned
      expression >= 0 is always true [-Wtautological-compare]
  if (ret >= 0){
      ~~~ ^  ~
```

Note: this was found by compiling with a recent clang. I have no way of
testing this. this change looks innocent, but many do. either merge and
pray or test and merge ,-)

Signed-off-by: Martin Zenzes <martin.zenzes@dfki.de>