### PR TITLE
provide empty virtual destructor for "class Parser"

### DIFF
--- a/src/Bus.hpp
+++ b/src/Bus.hpp
@@ -21,6 +21,7 @@ public:
 	 * Give the Constructer the bus, which it belongs to
 	 */
 	Parser(Bus *bus);
+	virtual ~Parser(){};
 
 	/**
 	 * read packed calls the readPacked from IOBus, if this readPacked is used only the extract packed


### PR DESCRIPTION
fix this longstanding, annoying and possibly serious warning:

```
.../drivers/iodrivers_base/build_dbg/include/_iodrivers_base_/iodrivers_base/Bus.hpp:18:7:
        warning: ‘class iodrivers_base::Parser’ has virtual functions and
        accessible non-virtual destructor [-Wnon-virtual-dtor]
 class Parser{
       ^
```

a virtual destructor is required when you invoke delete on a pointer to
a derived object via a base class (http://stackoverflow.com/a/8698493/4658481)

not exactly sure if this is what we want. alternative is making the
destructor protected, prohibiting the destruction of a derived object
via a base-class pointer (http://stackoverflow.com/a/3246823/4658481)

opinions?

Signed-off-by: Martin Zenzes <martin.zenzes@dfki.de>