### PR TITLE
take ownership of the listener

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -113,7 +113,8 @@ void Driver::addListener(IOListener* listener)
 
 void Driver::removeListener(IOListener* listener)
 {
-    m_listeners.erase(listener);
+    if (m_listeners.erase(listener))
+        delete listener;
 }
 
 void Driver::clear()


### PR DESCRIPTION
Take ownership of the listener to prevent double-free in the task destructor and the driver.
